### PR TITLE
Add EMI support and Fabric compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ build
 eclipse
 run
 runs
+local.properties

--- a/build.gradle
+++ b/build.gradle
@@ -4,3 +4,10 @@ plugins {
     // see https://projects.neoforged.net/neoforged/moddevgradle for new versions
     id 'net.neoforged.moddev' version '0.1.110' apply false
 }
+
+allprojects {
+    repositories {
+        mavenCentral()
+        maven { url 'https://maven.terraformersmc.com' }
+    }
+}

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -21,6 +21,11 @@ dependencies {
     // fabric and neoforge both bundle mixinextras, so it is safe to use it in common
     compileOnly group: 'io.github.llamalad7', name: 'mixinextras-common', version: '0.3.5'
     annotationProcessor group: 'io.github.llamalad7', name: 'mixinextras-common', version: '0.3.5'
+
+    compileOnly "dev.emi:emi-xplat-mojmap:${emi_version}:api"
+
+    //TODO remove this before committing changes
+    compileOnly "dev.emi:emi-xplat-mojmap:${emi_version}"
 }
 
 configurations {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -23,9 +23,6 @@ dependencies {
     annotationProcessor group: 'io.github.llamalad7', name: 'mixinextras-common', version: '0.3.5'
 
     compileOnly "dev.emi:emi-xplat-mojmap:${emi_version}:api"
-
-    //TODO remove this before committing changes
-    compileOnly "dev.emi:emi-xplat-mojmap:${emi_version}"
 }
 
 configurations {

--- a/common/src/main/java/tfar/craftingstation/emi/CraftingStationEmiHandler.java
+++ b/common/src/main/java/tfar/craftingstation/emi/CraftingStationEmiHandler.java
@@ -1,0 +1,35 @@
+package tfar.craftingstation.emi;
+
+import dev.emi.emi.api.recipe.EmiRecipe;
+import dev.emi.emi.api.recipe.VanillaEmiRecipeCategories;
+import dev.emi.emi.api.recipe.handler.StandardRecipeHandler;
+import net.minecraft.world.inventory.Slot;
+import org.jetbrains.annotations.Nullable;
+import tfar.craftingstation.menu.CraftingStationMenu;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+public class CraftingStationEmiHandler implements StandardRecipeHandler<CraftingStationMenu> {
+    @Override
+    public List<Slot> getInputSources(CraftingStationMenu menu) {
+        return menu.slots.stream().filter(slot -> slot.index != 0).toList();
+    }
+
+    @Override
+    public List<Slot> getCraftingSlots(CraftingStationMenu menu) {
+        return IntStream.range(1, 1 + 9)
+                .mapToObj(menu::getSlot)
+                .toList();
+    }
+
+    @Override
+    public @Nullable Slot getOutputSlot(CraftingStationMenu menu) {
+        return menu.getSlot(0);
+    }
+
+    @Override
+    public boolean supportsRecipe(EmiRecipe recipe) {
+        return recipe.getCategory() == VanillaEmiRecipeCategories.CRAFTING && recipe.supportsRecipeTree();
+    }
+}

--- a/common/src/main/java/tfar/craftingstation/emi/CraftingStationEmiPlugin.java
+++ b/common/src/main/java/tfar/craftingstation/emi/CraftingStationEmiPlugin.java
@@ -1,0 +1,19 @@
+package tfar.craftingstation.emi;
+
+import dev.emi.emi.api.EmiEntrypoint;
+import dev.emi.emi.api.EmiPlugin;
+import dev.emi.emi.api.EmiRegistry;
+import dev.emi.emi.api.recipe.VanillaEmiRecipeCategories;
+import dev.emi.emi.api.stack.EmiStack;
+import tfar.craftingstation.init.ModBlocks;
+import tfar.craftingstation.platform.Services;
+
+@EmiEntrypoint
+public class CraftingStationEmiPlugin implements EmiPlugin {
+    @Override
+    public void register(EmiRegistry registry) {
+        registry.addWorkstation(VanillaEmiRecipeCategories.CRAFTING, EmiStack.of(ModBlocks.crafting_station));
+        registry.addWorkstation(VanillaEmiRecipeCategories.CRAFTING, EmiStack.of(ModBlocks.crafting_station_slab));
+        registry.addRecipeHandler(Services.PLATFORM.customMenu(), new CraftingStationEmiHandler());
+    }
+}

--- a/common/src/main/resources/craftingstation.accesswidener
+++ b/common/src/main/resources/craftingstation.accesswidener
@@ -23,3 +23,7 @@ extendable method net/minecraft/world/inventory/AbstractContainerMenu synchroniz
 accessible field net/minecraft/world/inventory/AbstractContainerMenu remoteSlots Lnet/minecraft/core/NonNullList;
 accessible field net/minecraft/world/inventory/AbstractContainerMenu synchronizer Lnet/minecraft/world/inventory/ContainerSynchronizer;
 accessible field net/minecraft/world/inventory/AbstractContainerMenu suppressRemoteUpdates Z
+
+# Rendering
+accessible field net/minecraft/client/gui/screens/inventory/CraftingScreen CRAFTING_TABLE_LOCATION Lnet/minecraft/resources/ResourceLocation;
+accessible field net/minecraft/client/gui/screens/inventory/CreativeModeInventoryScreen SCROLLER_SPRITE Lnet/minecraft/resources/ResourceLocation;

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -15,6 +15,13 @@ dependencies {
         modImplementation "me.shedaniel:RoughlyEnoughItems-fabric:$rei_version"
         modImplementation "me.shedaniel.cloth:cloth-config-fabric:$cloth_config_version"
         modImplementation "dev.architectury:architectury-fabric:$architectury_version"
+    } else {
+        modCompileOnly "me.shedaniel:RoughlyEnoughItems-fabric:$rei_version"
+    }
+
+    modCompileOnly "dev.emi:emi-fabric:$emi_version:api"
+    if (project.use_emi) {
+        modRuntimeOnly "dev.emi:emi-fabric:$emi_version"
     }
 }
 

--- a/fabric/src/main/java/tfar/craftingstation/CraftingStationFabric.java
+++ b/fabric/src/main/java/tfar/craftingstation/CraftingStationFabric.java
@@ -1,9 +1,11 @@
 package tfar.craftingstation;
 
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.CreativeModeTabs;
 import net.minecraft.world.item.Item;
 import tfar.craftingstation.init.ModBlockEntityTypes;
 import tfar.craftingstation.init.ModBlocks;
@@ -14,10 +16,14 @@ public class CraftingStationFabric implements ModInitializer {
     @Override
     public void onInitialize() {
         CraftingStation.init();
-        // register a new block here
+
         Registry.register(BuiltInRegistries.BLOCK, CraftingStation.id("crafting_station"), ModBlocks.crafting_station);
         Registry.register(BuiltInRegistries.BLOCK, CraftingStation.id("crafting_station_slab"),ModBlocks.crafting_station_slab);
-        // register a new item here
+        ItemGroupEvents.modifyEntriesEvent(CreativeModeTabs.FUNCTIONAL_BLOCKS).register(entries -> {
+            entries.accept(ModBlocks.crafting_station);
+            entries.accept(ModBlocks.crafting_station_slab);
+        });
+
         Item.Properties properties = new Item.Properties();
         Registry.register(BuiltInRegistries.ITEM, CraftingStation.id("crafting_station"),new BlockItem(ModBlocks.crafting_station, properties));
         Registry.register(BuiltInRegistries.ITEM, CraftingStation.id("crafting_station_slab"),new BlockItem(ModBlocks.crafting_station_slab, properties));

--- a/fabric/src/main/resources/META-INF/services/com.example.examplemod.platform.services.IPlatformHelper
+++ b/fabric/src/main/resources/META-INF/services/com.example.examplemod.platform.services.IPlatformHelper
@@ -1,1 +1,0 @@
-com.example.examplemod.platform.FabricPlatformHelper

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -18,7 +18,8 @@
         "main": [
             "tfar.craftingstation.CraftingStationFabric"
         ],
-        "client": ["tfar.craftingstation.ModClientFabric"]
+        "client": ["tfar.craftingstation.ModClientFabric"],
+        "emi": ["tfar.craftingstation.emi.CraftingStationEmiPlugin"]
     },
     "mixins": [
         "${mod_id}.mixins.json",
@@ -32,6 +33,6 @@
     },
     "suggests": {
         "another-mod": "*"
-    }
+    },
+    "accessWidener": "craftingstation.accesswidener"
 }
-  

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,11 +31,14 @@ neoforge_version=21.1.72
 neoforge_loader_version_range=[4,)
 
 #Other mods
+use_jei=false
 use_rei=false
+use_emi=false
 rei_version=16.0.729
 cloth_config_version=15.0.127
 architectury_version=13.0.3
-jei_version = 19.21.0.246
+jei_version=19.21.0.246
+emi_version=1.1.22+1.21.1
 
 # Gradle
 org.gradle.jvmargs=-Xmx3G

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -46,7 +46,15 @@ neoForge {
 dependencies {
 
     compileOnly("mezz.jei:jei-${minecraft_version}-neoforge-api:${jei_version}")
-    runtimeOnly("mezz.jei:jei-${minecraft_version}-neoforge:${jei_version}")
+    compileOnly "dev.emi:emi-neoforge:${emi_version}:api"
+
+    if (project.use_jei) {
+        runtimeOnly("mezz.jei:jei-${minecraft_version}-neoforge:${jei_version}")
+    }
+    if (project.use_emi) {
+        runtimeOnly "dev.emi:emi-neoforge:${emi_version}"
+    }
+
     runtimeOnly "curse.maven:sophisticated-core-618298:5869813"
     runtimeOnly "curse.maven:sophisticated-storage-619320:5871955"
     implementation "curse.maven:metal-barrels-324985:5554620"


### PR DESCRIPTION
Adds EMI handling for its "shift-click to craft exact amount necessary", cleans up code to ensure compile-time dependencies are always present, and fixes a couple things for Fabric related to Accesswidener weirdness and creative tab entries

This should also close #2 